### PR TITLE
fix: registries

### DIFF
--- a/contracts/registry/LineRegistry.sol
+++ b/contracts/registry/LineRegistry.sol
@@ -2,7 +2,7 @@
 
 pragma solidity ^0.8.13;
 
-import {Context} from "@openzeppelin/contracts/utils/Context.sol";
+import {Context} from '@openzeppelin/contracts/utils/Context.sol';
 
 import {IServiceProviderRegistry, Role} from '../interfaces/IServiceProviderRegistry.sol';
 import {ILineRegistry} from '../interfaces/ILineRegistry.sol';

--- a/contracts/registry/ServiceProviderRegistry.sol
+++ b/contracts/registry/ServiceProviderRegistry.sol
@@ -9,8 +9,6 @@ import {AccessControl} from '@openzeppelin/contracts/access/AccessControl.sol';
 import {AbstractTimestampedAccessControl} from '../access/AbstractTimestampedAccessControl.sol';
 import {AbstractWhitelistExpiry} from '../access/AbstractWhitelistExpiry.sol';
 
-uint256 constant WHITELIST_EXPIRY = 180 days;
-
 /// @title A source of service providers
 /// @author mfw78 <mfw78@protonmail.com>
 contract ServiceProviderRegistry is IServiceProviderRegistry, AccessControl, AbstractWhitelistExpiry {
@@ -66,7 +64,7 @@ contract ServiceProviderRegistry is IServiceProviderRegistry, AccessControl, Abs
         return keccak256(abi.encodePacked(which, uint256(what)));
     }
 
-    constructor() AbstractWhitelistExpiry(block.timestamp + WHITELIST_EXPIRY) {
+    constructor(uint256 whitelistTTL) AbstractWhitelistExpiry(block.timestamp + whitelistTTL) {
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
     }
 


### PR DESCRIPTION
TTL is now configurable for whitelists and not hardcoded. Improved deployment / runtime efficiency by using minimalist access control system for `LineRegistry`.