### PR TITLE
chore: 🤖 revised deploy scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ reports/
 coverage*
 inheritance-graph.dot
 docs/
+deployments/
 
 # dotenv
 .env*

--- a/deploy/001.ts
+++ b/deploy/001.ts
@@ -1,12 +1,21 @@
 /* eslint-disable camelcase */
 import { HardhatRuntimeEnvironment } from 'hardhat/types'
 import { DeployFunction } from 'hardhat-deploy/types'
+import { network } from 'hardhat'
+
+const WHITELIST_TTL = 60 * 60 * 24 * 180
+const LINE_REGISTRY_SELF_REGISTER = 1 // allows enrolling one's self in the line registry
+
+const GEMJOIN_EIP712_NAME = 'MockERC20GemJoin'
+const GEMJOIN_EIP712_VERSION = '1'
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre
   const { deploy } = deployments
 
   const { deployer } = await getNamedAccounts()
+
+  console.log('Deployer address:', deployer)
 
   // --- Deploy the registries
   await deploy('TimestampRegistry', {
@@ -19,14 +28,14 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     from: deployer,
     log: true,
     autoMine: true,
-    args: [Number(60 * 60 * 24 * 180).toString()]
+    args: [WHITELIST_TTL.toString()]
   })
 
   await deploy('LineRegistry', {
     from: deployer,
     log: true,
     autoMine: true,
-    args: [serviceProviderRegistryDeploy.address, '1']
+    args: [serviceProviderRegistryDeploy.address, LINE_REGISTRY_SELF_REGISTER]
   })
 
   const vatDeploy = await deploy('Vat', {
@@ -35,24 +44,35 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     autoMine: true
   })
 
-  const mockERC20Deploy = await deploy('MockERC20', {
-    from: deployer,
-    log: true,
-    autoMine: true
-  })
+  if (!network.live) {
+    await deploy('HashLib', {
+      from: deployer,
+      log: true,
+      autoMine: true
+    })
+  }
 
-  await deploy('HashLib', {
-    from: deployer,
-    log: true,
-    autoMine: true
-  })
+  if (!network.tags.production) {
+    const mockERC20Deploy = await deploy('MockERC20', {
+      from: deployer,
+      log: true,
+      autoMine: true
+    })
 
-  await deploy('GemJoin', {
-    from: deployer,
-    log: true,
-    autoMine: true,
-    args: ['MockERC20GemJoin', '1', vatDeploy.address, mockERC20Deploy.address]
-  })
+    if (mockERC20Deploy.newlyDeployed) {
+      await deploy('GemJoin', {
+        from: deployer,
+        log: true,
+        autoMine: true,
+        args: [
+          GEMJOIN_EIP712_NAME,
+          GEMJOIN_EIP712_VERSION,
+          vatDeploy.address,
+          mockERC20Deploy.address
+        ]
+      })
+    }
+  }
 }
 
 export default func

--- a/deploy/001.ts
+++ b/deploy/001.ts
@@ -64,12 +64,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         from: deployer,
         log: true,
         autoMine: true,
-        args: [
-          GEMJOIN_EIP712_NAME,
-          GEMJOIN_EIP712_VERSION,
-          vatDeploy.address,
-          mockERC20Deploy.address
-        ]
+        args: [GEMJOIN_EIP712_NAME, GEMJOIN_EIP712_VERSION, vatDeploy.address, mockERC20Deploy.address]
       })
     }
   }

--- a/deploy/002.ts
+++ b/deploy/002.ts
@@ -34,43 +34,24 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
       for (const wallet of TEST_WALLETS) {
         for (const role of [WHITELIST_ROLE, DEFAULT_ADMIN_ROLE]) {
-          const hasRole = await read(
-            'ServiceProviderRegistry',
-            {},
-            'hasRole',
-            role, wallet
-          )
+          const hasRole = await read('ServiceProviderRegistry', {}, 'hasRole', role, wallet)
           if (!hasRole) calls.push(iface.encodeFunctionData('grantRole', [role, wallet]))
         }
       }
 
       // no problems executing this all the time, just wastes test gas.
       if (calls.length > 0) {
-        await execute(
-          'ServiceProviderRegistry',
-          { from: deployer, log: true },
-          'multicall',
-          calls
-        )
+        await execute('ServiceProviderRegistry', { from: deployer, log: true }, 'multicall', calls)
       }
 
       // everytime this runs we will gift tokens
       // mint test tokens to team testing wallets
       for await (const wallet of TEST_WALLETS) {
-        await execute(
-          'MockERC20',
-          { from: deployer, log: true },
-          'mint', wallet, NUM_TEST_TOKENS
-        )
+        await execute('MockERC20', { from: deployer, log: true }, 'mint', wallet, NUM_TEST_TOKENS)
       }
 
       // make sure that the gemjoin contract is rely'd
-      await execute(
-        'Vat',
-        { from: deployer, log: true },
-        'rely',
-        mockERC20GemJoinDeploy.address
-      )
+      await execute('Vat', { from: deployer, log: true }, 'rely', mockERC20GemJoinDeploy.address)
     }
   }
 }

--- a/deploy/002.ts
+++ b/deploy/002.ts
@@ -1,0 +1,79 @@
+/* eslint-disable camelcase */
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
+import { DeployFunction } from 'hardhat-deploy/types'
+import { utils } from 'ethers'
+import { ServiceProviderRegistry__factory } from '../typechain'
+
+const TEAM_1 = '0xcF76325B47a0edF0723DC4071A73C41B4FBc44eA'
+const TEAM_2 = '0xb9C79303DC35548bCc9dDf7cF324bBdBC824F2E7'
+const TEAM_3 = '0x6633773ad50794aF5c577566D9b94991E7Abdb7B'
+
+const DEFAULT_ADMIN_ROLE = '0x0000000000000000000000000000000000000000000000000000000000000000'
+const WHITELIST_ROLE = '0xc47988f847a97765b43d54e7729b079892810861c3449fdf92db036b5afa0504'
+const NUM_TEST_TOKENS = utils.parseEther('1000000000')
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts, network } = hre
+  const { execute, read } = deployments
+
+  const { deployer } = await getNamedAccounts()
+
+  const TEST_WALLETS = [deployer, TEAM_1, TEAM_2, TEAM_3]
+
+  const serviceProviderRegistryDeploy = await hre.deployments.get('ServiceProviderRegistry')
+  const vatDeploy = await hre.deployments.get('Vat')
+  const mockERC20GemJoinDeploy = await hre.deployments.get('GemJoin')
+
+  // only do these actions if deploying to a non-local blockchain (ie. live)
+  if (network.live) {
+    // If this is a staging (ie. non production environment)
+    if (!network.tags.production) {
+      // set access requirements
+      const iface = ServiceProviderRegistry__factory.createInterface()
+      const calls: string[] = []
+
+      for (const wallet of TEST_WALLETS) {
+        for (const role of [WHITELIST_ROLE, DEFAULT_ADMIN_ROLE]) {
+          const hasRole = await read(
+            'ServiceProviderRegistry',
+            {},
+            'hasRole',
+            role, wallet
+          )
+          if (!hasRole) calls.push(iface.encodeFunctionData('grantRole', [role, wallet]))
+        }
+      }
+
+      // no problems executing this all the time, just wastes test gas.
+      if (calls.length > 0) {
+        await execute(
+          'ServiceProviderRegistry',
+          { from: deployer, log: true },
+          'multicall',
+          calls
+        )
+      }
+
+      // everytime this runs we will gift tokens
+      // mint test tokens to team testing wallets
+      for await (const wallet of TEST_WALLETS) {
+        await execute(
+          'MockERC20',
+          { from: deployer, log: true },
+          'mint', wallet, NUM_TEST_TOKENS
+        )
+      }
+
+      // make sure that the gemjoin contract is rely'd
+      await execute(
+        'Vat',
+        { from: deployer, log: true },
+        'rely',
+        mockERC20GemJoinDeploy.address
+      )
+    }
+  }
+}
+export default func
+func.tags = ['StagingEnv']
+func.dependencies = ['Videre']


### PR DESCRIPTION
This PR splits the deployment to facilitate local unit testing, staging environments, and eventually production environments for deployment. In the deploy scripts, the use of `execute` from `hardhat-deploy` is favoured over direct use of `ethers` as this allows for deployment-wide custom gas prices to be set - this is because some RPC endpoints do not give friendly gas estimation when deploying, and this way we can override that behaviour.