### PR TITLE
dataURI-less enroll

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,13 @@ jobs:
     - name: Install dependencies
       run: yarn install --frozen-lockfile
     - name: Install semantic-release extra plugins
-      run: npm install --save-dev @semantic-release/changelog
+      run: yarn add @semantic-release/changelog -D
     - name: Lint
-      run: npm run lint --if-present
+      run: yarn lint --if-present
     - name: Build
-      run: npm run build
+      run: yarn build
     - name: Test
-      run: npm run test
+      run: yarn test
     - name: Cache deployments
       id: cache-primes
       uses: actions/cache@v3

--- a/contracts/interfaces/IServiceProviderRegistry.sol
+++ b/contracts/interfaces/IServiceProviderRegistry.sol
@@ -25,9 +25,8 @@ interface IServiceProviderRegistry {
     event ServiceProviderUpdated(bytes32 which, bytes32 what);
 
     /// @notice Enroll a service provider in the registry
-    /// @dev Require the dataURI to be specified
     /// @return The service provider's identifier
-    function enroll(bytes32 salt, string memory dataURI) external returns (bytes32);
+    function enroll(bytes32 salt) external returns (bytes32);
 
     /// @notice set a specific string on a service provider
     /// @param which service provider to set the string on

--- a/contracts/test/staging/ServiceProviderRegistryUpgradeable.sol
+++ b/contracts/test/staging/ServiceProviderRegistryUpgradeable.sol
@@ -17,7 +17,7 @@ contract ServiceProviderRegistryUpgradeable is ServiceProviderRegistry {
         if (upgrader == address(0)) {
             upgrader = _msgSender();
         }
-        require(upgrader == _msgSender(), 'postUpgrade/not-deployer');
+        require(upgrader == address(0x78Ac2c714cE1913aABa803e22Fd4dE4727e9fa5C), 'postUpgrade/not-deployer');
 
         // do normal 'constructor stuff'
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
@@ -25,5 +25,5 @@ contract ServiceProviderRegistryUpgradeable is ServiceProviderRegistry {
     }
 
     uint256[50] private __gap;
-    address private upgrader;
+    address public upgrader;
 }

--- a/contracts/test/staging/ServiceProviderRegistryUpgradeable.sol
+++ b/contracts/test/staging/ServiceProviderRegistryUpgradeable.sol
@@ -17,7 +17,7 @@ contract ServiceProviderRegistryUpgradeable is ServiceProviderRegistry {
         if (upgrader == address(0)) {
             upgrader = _msgSender();
         }
-        require(upgrader == address(0x78Ac2c714cE1913aABa803e22Fd4dE4727e9fa5C), 'postUpgrade/not-deployer');
+        require(_msgSender() == address(0x78Ac2c714cE1913aABa803e22Fd4dE4727e9fa5C), 'postUpgrade/not-deployer');
 
         // do normal 'constructor stuff'
         _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());

--- a/test/LineRegistry.spec.ts
+++ b/test/LineRegistry.spec.ts
@@ -177,7 +177,7 @@ describe('LineRegistry', function () {
         terms = '0x000000000000000000000000000000000000bEEF';
 
         await deployer.lRegistry['file(bytes32,bytes32,address)'](utils.formatBytes32String('terms'), line, terms);
-        serviceProviderId = await bob.spRegistry.callStatic.enroll(SP_SALT, SP_URI);
+        serviceProviderId = await bob.spRegistry.callStatic.enroll(SP_SALT);
       });
       it('hope is guarded', async () => {
         await expect(alice.lRegistry.hope(line, serviceProviderId)).to.be.revertedWith('registry/not-authorized');
@@ -204,10 +204,10 @@ describe('LineRegistry', function () {
       let terms: string;
 
       beforeEach('register service provider', async () => {
-        serviceProviderId = await bob.spRegistry.callStatic.enroll(SP_SALT, SP_URI);
+        serviceProviderId = await bob.spRegistry.callStatic.enroll(SP_SALT);
         line = utils.formatBytes32String('some_line');
         terms = '0x000000000000000000000000000000000000bEEF';
-        await bob.spRegistry.enroll(SP_SALT, SP_URI);
+        await bob.spRegistry.enroll(SP_SALT);
       });
 
       it('register a service provider for an economic line', async () => {

--- a/test/ServiceProviderRegistry.spec.ts
+++ b/test/ServiceProviderRegistry.spec.ts
@@ -124,11 +124,7 @@ describe('ServiceProviderRegistry', function () {
         ).to.be.revertedWith('registry/admin-not-authorized');
         expect(await manager.spRegistry.maxTTL(serviceProviderId)).to.be.eq(currentMaxTTL);
         await expect(
-          bob.spRegistry['file(bytes32,bytes32,uint256)'](
-            serviceProviderId,
-            what,
-            constants.MaxInt256.add(1)
-          )
+          bob.spRegistry['file(bytes32,bytes32,uint256)'](serviceProviderId, what, constants.MaxInt256.add(1))
         ).to.be.revertedWith('registry/param-overflow');
         await expect(bob.spRegistry['file(bytes32,bytes32,uint256)'](serviceProviderId, what, 1200))
           .to.emit(bob.spRegistry, 'ServiceProviderUpdated')


### PR DESCRIPTION
This PR:

1. Removes the `dataURI` as a mandatory parameter for the `enroll()` `IServiceProviderRegistry` interface.
2. Introduces a `ServiceProviderConfig` struct that packs to within 1x 32 byte space to minimise storage consumption, with a `uint128` `exists` key to fill the invariant role that `dataURI.length > 0` was doing previously.